### PR TITLE
Fixes for multi-devstack via new make targets for querying & stopping services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ stop.all: dev.stop
 
 stop.xqueue: dev.stop.xqueue+xqueue_consumer
 
-dev.kill: ## Kill specific services, separated by plus-signs.
+dev.kill: ## Kill all services.
 	(test -d .docker-sync && docker-sync stop) || true ## Ignore failure here
 	docker-compose $(DOCKER_COMPOSE_FILES) stop
 

--- a/Makefile.edx
+++ b/Makefile.edx
@@ -24,7 +24,7 @@ dev.provision.whitelabel:
 # AND the test must be setup using the 'dev.provision.whitelabel' target.
 whitelabel-tests:
 	docker-compose run -T -d --name=devstack.whitelabel --network=devstack_default -v ${DEVSTACK_WORKSPACE}/edx-e2e-tests:/edx-e2e-tests -v ${DEVSTACK_WORKSPACE}/edx-platform:/edx-e2e-tests/lib/edx-platform --env-file ${DEVSTACK_WORKSPACE}/edx-e2e-tests/devstack_env edxops/e2e
-	docker cp ${DEVSTACK_WORKSPACE}/edx-themes/edx-platform/run_whitelabel_tests.sh $(docker-compose ps -q devstack.whitelabel)":/tmp/run_whitelabel_tests.sh
+	docker cp ${DEVSTACK_WORKSPACE}/edx-themes/edx-platform/run_whitelabel_tests.sh $(make --silent dev.print-container.studio)":/tmp/run_whitelabel_tests.sh
 	docker-compose exec devstack.whitelabel env TEST_ENV=devstack TERM=$(TERM) bash /tmp/run_whitelabel_tests.sh
 
 whitelabel-cleanup:

--- a/Makefile.edx
+++ b/Makefile.edx
@@ -24,7 +24,7 @@ dev.provision.whitelabel:
 # AND the test must be setup using the 'dev.provision.whitelabel' target.
 whitelabel-tests:
 	docker-compose run -T -d --name=devstack.whitelabel --network=devstack_default -v ${DEVSTACK_WORKSPACE}/edx-e2e-tests:/edx-e2e-tests -v ${DEVSTACK_WORKSPACE}/edx-platform:/edx-e2e-tests/lib/edx-platform --env-file ${DEVSTACK_WORKSPACE}/edx-e2e-tests/devstack_env edxops/e2e
-	docker cp ${DEVSTACK_WORKSPACE}/edx-themes/edx-platform/run_whitelabel_tests.sh $(make --silent dev.print-container.studio)":/tmp/run_whitelabel_tests.sh
+	docker cp ${DEVSTACK_WORKSPACE}/edx-themes/edx-platform/run_whitelabel_tests.sh $(make --silent dev.print-container.devstack.whitelabel)":/tmp/run_whitelabel_tests.sh
 	docker-compose exec devstack.whitelabel env TEST_ENV=devstack TERM=$(TERM) bash /tmp/run_whitelabel_tests.sh
 
 whitelabel-cleanup:

--- a/README.rst
+++ b/README.rst
@@ -773,20 +773,20 @@ Set a PDB breakpoint anywhere in the code using:
 
 and your attached session will offer an interactive PDB prompt when the breakpoint is hit.
 
-To detach from the container, you'll need to stop the container with:
+You may be able to detach from the container with the ``Ctrl-P, Ctrl-Q`` key sequence.
+If that doesn't work, you will have either close your terminal window,
+stop the container with:
 
 .. code:: sh
 
-    make stop
+    make dev.stop.<service>
 
-or a manual Docker command to bring down the container:
+or kill the container with:
 
 .. code:: sh
 
-   docker kill $(docker ps -a -q --filter="name=edx.devstack.<container name>")
+   make dev.kill.<service>
 
-Alternatively, some terminals allow detachment from a running container with the
-``Ctrl-P, Ctrl-Q`` key sequence.
 
 Running LMS and Studio Tests
 ----------------------------

--- a/docs/devpi.rst
+++ b/docs/devpi.rst
@@ -60,6 +60,6 @@ Monitoring devpi
 ----------------
 
 You can monitor the devpi logs by running this command on the host:
-``docker logs -f edx.devstack.devpi`` or looking at the output in
+``make devpi-logs`` or looking at the output in
 Kitematic. You can also check the devpi server status by visiting:
 http://localhost:3141/+status

--- a/gather-feature-toggle-state.sh
+++ b/gather-feature-toggle-state.sh
@@ -12,20 +12,24 @@ if [ -e feature-toggle-data ]; then
 fi
 mkdir feature-toggle-data
 
-docker-compose exec credentials bash -c 'source /edx/app/credentials/credentials_env && python /edx/app/credentials/credentials/manage.py dumpdata waffle --format=json > /edx/app/credentials/credentials/credentials_waffle.json'
-docker cp "$(docker-compose ps -q credentials)":/edx/app/credentials/credentials/credentials_waffle.json feature-toggle-data
-docker-compose exec credentials bash -c 'rm /edx/app/credentials/credentials/credentials_waffle.json'
+credentials_id="$(make --silent dev.print-container.credentials)"
+docker exec -t "$credentials_id" bash -c 'source /edx/app/credentials/credentials_env && python /edx/app/credentials/credentials/manage.py dumpdata waffle --format=json > /edx/app/credentials/credentials/credentials_waffle.json'
+docker cp "$credentials_id":/edx/app/credentials/credentials/credentials_waffle.json feature-toggle-data
+docker exec -t "$credentials_id" bash -c 'rm /edx/app/credentials/credentials/credentials_waffle.json'
 
-docker-compose exec discovery bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py dumpdata waffle --format=json > /edx/app/discovery/discovery/discovery_waffle.json'
-docker cp "$(docker-compose ps -q discovery)":/edx/app/discovery/discovery/discovery_waffle.json feature-toggle-data
-docker-compose exec discovery bash -c '> /edx/app/discovery/discovery/discovery_waffle.json'
+discovery_id="$(make --silent dev.print-container.discovery)"
+docker exec -t "$discovery_id" bash -c 'source /edx/app/discovery/discovery_env && python /edx/app/discovery/discovery/manage.py dumpdata waffle --format=json > /edx/app/discovery/discovery/discovery_waffle.json'
+docker cp "$discovery_id":/edx/app/discovery/discovery/discovery_waffle.json feature-toggle-data
+docker exec -t "$discovery_id" bash -c '> /edx/app/discovery/discovery/discovery_waffle.json'
 
-docker-compose exec ecommerce bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py dumpdata waffle --format=json > /edx/app/ecommerce/ecommerce/ecommerce_waffle.json'
-docker cp "$(docker-compose ps -q ecommerce)":/edx/app/ecommerce/ecommerce/ecommerce_waffle.json feature-toggle-data
-docker-compose exec ecommerce bash -c 'rm /edx/app/ecommerce/ecommerce/ecommerce_waffle.json'
+ecommerce_id="$(make --silent dev.print-container.ecommerce)"
+docker exec -t "$ecommerce_id" bash -c 'source /edx/app/ecommerce/ecommerce_env && python /edx/app/ecommerce/ecommerce/manage.py dumpdata waffle --format=json > /edx/app/ecommerce/ecommerce/ecommerce_waffle.json'
+docker cp "$ecommerce_id":/edx/app/ecommerce/ecommerce/ecommerce_waffle.json feature-toggle-data
+docker exec -t "$ecommerce_id" bash -c 'rm /edx/app/ecommerce/ecommerce/ecommerce_waffle.json'
 
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms dumpdata waffle --format=json > /edx/app/edxapp/edx-platform/lms_waffle.json'
-docker-compose exec lms bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms dumpdata waffle_utils --format=json > /edx/app/edxapp/edx-platform/lms_waffle_utils.json'
-docker cp "$(docker-compose ps -q lms)":/edx/app/edxapp/edx-platform/lms_waffle.json feature-toggle-data
-docker cp "$(docker-compose ps -q lms)":/edx/app/edxapp/edx-platform/lms_waffle_utils.json feature-toggle-data
-docker-compose exec lms bash -c 'rm /edx/app/edxapp/edx-platform/lms_waffle*.json'
+lms_id="$(make --silent dev.print-container.lms)"
+docker exec -t "$lms_id" bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms dumpdata waffle --format=json > /edx/app/edxapp/edx-platform/lms_waffle.json'
+docker exec -t "$lms_id" bash -c 'source /edx/app/edxapp/edxapp_env && python /edx/app/edxapp/edx-platform/manage.py lms dumpdata waffle_utils --format=json > /edx/app/edxapp/edx-platform/lms_waffle_utils.json'
+docker cp "$lms_id":/edx/app/edxapp/edx-platform/lms_waffle.json feature-toggle-data
+docker cp "$lms_id":/edx/app/edxapp/edx-platform/lms_waffle_utils.json feature-toggle-data
+docker exec -t "$lms_id" bash -c 'rm /edx/app/edxapp/edx-platform/lms_waffle*.json'

--- a/provision-e2e.sh
+++ b/provision-e2e.sh
@@ -10,7 +10,7 @@ elif [ ! -d "$DEVSTACK_WORKSPACE" ]; then
 fi
 
 # Copy the test course tarball into the studio container
-docker cp ${DEVSTACK_WORKSPACE}/edx-e2e-tests/upload_files/course.tar.gz "$(docker-compose ps -q studio)":/tmp/
+docker cp ${DEVSTACK_WORKSPACE}/edx-e2e-tests/upload_files/course.tar.gz "$(make --silent dev.print-container.studio)":/tmp/
 
 # Extract the test course tarball
 docker-compose exec -T studio bash -c 'cd /tmp && tar xzf course.tar.gz'

--- a/update-dbs-init-sql-scripts.sh
+++ b/update-dbs-init-sql-scripts.sh
@@ -24,8 +24,7 @@ make dev.clone.ssh
 make dev.provision.services.lms+ecommerce
 
 # dump schema and data from mysql databases in the mysql docker container and copy them to current directory in docker host
-MYSQL_DOCKER_COMPOSE_SERVICE="mysql"
-MYSQL_DOCKER_CONTAINER="edx.devstack.${MYSQL_DOCKER_COMPOSE_SERVICE}"
+MYSQL_DOCKER_CONTAINER="$(make --silent dev.print-container.mysql)"
 for DB_NAME in "${DBS[@]}"; do
     DB_CREATION_SQL_SCRIPT="${DB_NAME}.sql"
     if [[ " ${EDXAPP_DBS[@]} " =~ " ${DB_NAME} " ]]; then


### PR DESCRIPTION
This is a work-in-progress amendment to @ztraboo 's [pull request to allow multiple devstacks to exist on one computer, isolated from one another](https://github.com/edx/devstack/pull/532).

### Context

`COMPOSE_PROJECT_NAME` is set in `options.mk` and can be overriden in `options.local.mk`. This works because the Makefile includes both those `.mk` files.

Thus, `COMPOSE_PROJECT_NAME` is in the environment for all `docker-compose` commands that are run from the Makefile. That environment variable has the effect of namespacing all Docker containers.

_So, you cannot reference a Devstack Docker container from its service's name alone -- you must also know the `COMPOSE_PROJECT_NAME`_

This works fine when `docker-compose` is invoked through the Makefile, either directly or indirectly via a script.

### The issue

Some Devstack scripts are expected to be runnable *without the Makefile*. When `docker-compose` commands are run from within those scripts, they do not know the value of `COMPOSE_PROJECT_NAME`. So, things like `$(docker-compose ps -q mysql)` will not give you the correct container name when `COMPOSE_PROJECT_NAME` is overridden to be anything other than `devstack`.

To observe the effect of this, run `bash gather-feature-toggle-state.sh` for a devstack whose `COMPOSE_PROJECT_NAME` isn't `devstack`:
```
~/devstack 🍀 bash gather-feature-toggle-state.sh
ERROR: No container found for credentials_1
must specify at least one container source
ERROR: No container found for credentials_1
ERROR: No container found for discovery_1
must specify at least one container source
ERROR: No container found for discovery_1
ERROR: No container found for ecommerce_1
must specify at least one container source
ERROR: No container found for ecommerce_1
ERROR: No container found for lms_1
ERROR: No container found for lms_1
must specify at least one container source
must specify at least one container source
ERROR: No container found for lms_1
```

### My proposed solution

This PR makes a new Makefile target `dev.print-container.<service>` which echoes the ID of the container associated with a service iff that service is running. As it is implemented with `docker-compose` and is inside the Makefile, it will respect the value of `COMPOSE_PROJECT_NAME`.

With that in place, scripts outside of the Makefile can replace:
```
docker <cmd> edx.devstack.<service> <args>
```
with:
```
docker <cmd> "$(make --silent dev.print-container.<service>)" <args>
```

### This PR also...

Adds `dev.stop.<services>` and `dev.kill.<services>`, and `dev.down.<services>` targets, which are now necessary for stopping and killing containers, as bare `docker-compose ...` do not factor in the `COMPOSE_PROJECT_NAME`.