### PR TITLE
Set COMPOSE_FILE environment variable in Makefile

### DIFF
--- a/provision-credentials.sh
+++ b/provision-credentials.sh
@@ -6,7 +6,7 @@
 name=credentials
 port=18150
 
-docker-compose $DOCKER_COMPOSE_FILES up -d $name
+docker-compose up -d $name
 
 echo -e "${GREEN}Installing requirements for ${name}...${NC}"
 docker-compose exec ${name}  bash -c 'source /edx/app/credentials/credentials_env && cd /edx/app/credentials/credentials && make requirements && make production-requirements' -- "$name"

--- a/provision-forum.sh
+++ b/provision-forum.sh
@@ -2,5 +2,5 @@ set -e
 set -o pipefail
 set -x
 
-docker-compose $DOCKER_COMPOSE_FILES up -d forum
+docker-compose up -d forum
 docker-compose exec -T forum bash -c 'source /edx/app/forum/ruby_env && cd /edx/app/forum/cs_comments_service && bundle install --deployment --path /edx/app/forum/.gem/'

--- a/provision-ida.sh
+++ b/provision-ida.sh
@@ -4,7 +4,7 @@ client_name=$2  # The name of the Oauth client stored in the edxapp DB.
 client_port=$3  # The port corresponding to this IDA service in devstack.
 container_name=${4:-$1} # (Optional) The name of the container.  If missing, will use app_name.
 
-docker-compose $DOCKER_COMPOSE_FILES up -d $app_name
+docker-compose up -d $app_name
 
 echo -e "${GREEN}Installing requirements for ${app_name}...${NC}"
 docker-compose exec ${container_name}  bash -c 'source /edx/app/$1/$1_env && cd /edx/app/$1/$1/ && make requirements' -- "$app_name"

--- a/provision-lms.sh
+++ b/provision-lms.sh
@@ -10,7 +10,7 @@ apps=( lms studio )
 
 # Bring edxapp containers online
 for app in "${apps[@]}"; do
-    docker-compose $DOCKER_COMPOSE_FILES up -d $app
+    docker-compose up -d $app
 done
 
 docker-compose exec -T lms bash -c 'source /edx/app/edxapp/edxapp_env && cd /edx/app/edxapp/edx-platform && NO_PYTHON_UNINSTALL=1 paver install_prereqs'

--- a/provision-marketing.sh
+++ b/provision-marketing.sh
@@ -7,7 +7,7 @@ set -x
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-docker-compose $DOCKER_COMPOSE_FILES up -d marketing
+docker-compose up -d marketing
 
 set +x
 echo -e "${YELLOW}edX Marketing Site is not fully provisioned yet.${NC}"

--- a/provision-registrar.sh
+++ b/provision-registrar.sh
@@ -3,7 +3,7 @@
 name=registrar
 port=18734
 
-docker-compose $DOCKER_COMPOSE_FILES up -d $name
+docker-compose up -d $name
 
 echo -e "${GREEN}Installing requirements for ${name}...${NC}"
 docker-compose exec ${name}  bash -c 'source /edx/app/registrar/registrar_env && cd /edx/app/registrar/registrar && make requirements' -- "$name"

--- a/provision-xqueue.sh
+++ b/provision-xqueue.sh
@@ -3,11 +3,11 @@ set -o pipefail
 set -x
 
 # Bring up XQueue, we don't need the consumer for provisioning
-docker-compose $DOCKER_COMPOSE_FILES up -d xqueue
+docker-compose up -d xqueue
 
 # Update dependencies
-docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && make requirements'
+docker-compose exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && make requirements'
 # Run migrations
-docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && python manage.py migrate'
+docker-compose exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && python manage.py migrate'
 # Add users that graders use to fetch data, there's one default user in Ansible which is part of our settings
-docker-compose $DOCKER_COMPOSE_FILES exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && python manage.py update_users' 
+docker-compose exec xqueue bash -c 'source /edx/app/xqueue/xqueue_env && cd /edx/app/xqueue/xqueue && python manage.py update_users' 


### PR DESCRIPTION
This variable specifies the docker compose YAML files that all calls to `docker-compose` should load.
For calls to docker-compose that source from the Makefile, this removes the need to pass
`-f file1.yml -f file2.yml ... -f fileN.yml` to docker-compose every single time we invoke it.

In the context of PR #532, this commit should fix the xqueue-shell and analyticspipeline-shell commands.