### PR TITLE
Make sure all uses of docker-compose pass through Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
         dev.nfs.setup devpi-password dev.provision \
         dev.provision.analytics_pipeline dev.provision.services \
         dev.provision.xqueue dev.ps dev.pull dev.repo.reset dev.reset \
-        dev.rm-stopped dev.status dev.stop dev.sync.daemon.start \
+        dev.restart dev.rm-stopped dev.status dev.stop dev.sync.daemon.start \
         dev.sync.provision dev.sync.requirements dev.sync.up dev.up dev.up.all \
         dev.up.analytics_pipeline dev.up.watchers dev.up.with-programs \
         discovery-shell down e2e-shell e2e-tests ecommerce-shell \
@@ -223,6 +223,12 @@ stop.watchers: dev.stop.lms_watcher+studio_watcher
 stop.all: dev.stop
 
 stop.xqueue: dev.stop.xqueue+xqueue_consumer
+
+dev.restart: ## Restart all services.
+	docker-compose restart $$(echo $* | tr + " ")
+
+dev.restart.%: ## Restart specific services, separated by plus-signs.
+	docker-compose restart $$(echo $* | tr + " ")
 
 dev.kill: ## Kill all services.
 	(test -d .docker-sync && docker-sync stop) || true ## Ignore failure here

--- a/README.rst
+++ b/README.rst
@@ -405,11 +405,11 @@ already being correcty provisioned.
 So, when in doubt, it may still be best to run the full ``make dev.provision``.
 
 Sometimes you may need to restart a particular application server. To do so,
-simply use the ``docker-compose restart`` command:
+simply use the ``make dev.restart.%`` command:
 
 .. code:: sh
 
-    docker-compose restart <service>
+    make dev.restart.<service>
 
 In all the above commands, ``<service>`` should be replaced with one of the following:
 
@@ -681,7 +681,7 @@ vary depending on the database. For all of the options, see ``provision.sql``.
 - Password: ``password``
 
 If you have trouble connecting, ensure the port was mapped successfully by
-running ``docker-compose ps`` and looking for a line like this:
+running ``make dev.ps`` and looking for a line like this:
 ``edx.devstack.mysql docker-entrypoint.sh mysql ... Up 0.0.0.0:3506→3306/tcp``.
 
 Switching branches
@@ -872,7 +872,7 @@ Check the logs
 
 If a container stops unexpectedly, you can look at its logs for clues::
 
-    docker-compose logs lms
+    make <service>-logs
 
 Update the code and images
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/destroy.sh
+++ b/destroy.sh
@@ -5,5 +5,5 @@ set -e
 read -p "This will delete all data in your devstack. Would you like to proceed? [y/n] " -r
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-    docker-compose -f docker-compose.yml -f docker-compose-watchers.yml -f docker-compose-host.yml -f docker-compose-themes.yml -f docker-compose-analytics-pipeline.yml down -v
+    docker-compose down -v
 fi

--- a/in
+++ b/in
@@ -1,7 +1,26 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
+# Run a command in a service's container.
+# Try to bring up the service if it isn't already up.
+# Example:
+#   ~/devstack> ./in registrar ls /edx/app/
+#   edx_ansible  nginx  registrar  supervisor
+# Example 2:
+#   ~/devstack> ./in registrar "cd /edx/app/registrar && ls"
+#   data	     registrar		    registrar.sh	  venvs
+#   devstack.sh  registrar_env	    registrar-workers.sh
+#   nodeenvs     registrar_gunicorn.py  staticfiles
 
-SERVICE=$1
+set -e
+set -o pipefail
+set -u
+
+service="$1"
 shift
-export DEVSTACK_WORKSPACE=${DEVSTACK_WORKSPACE:-$(pwd)/..}
 
-docker-compose -f docker-compose.yml -f docker-compose-host.yml -f docker-compose-themes.yml run $SERVICE exec "$@"
+container_id=$(make --silent dev.print-container."$service")
+if [[ -z "$container_id" ]]; then
+	make --silent dev.up."$service"
+	container_id=$(make --silent dev.print-container."$service")
+fi
+
+docker exec -it "$container_id" bash -c "$*"

--- a/load-db.sh
+++ b/load-db.sh
@@ -17,5 +17,6 @@ then
 fi
 
 echo "Loading the $1 database..."
-docker-compose exec -T mysql bash -c "mysql -uroot $1" < $1.sql
+mysql_container=$(make -s dev.print-container.mysql)
+docker exec "$mysql_container" bash -c "mysql -uroot $1" < $1.sql
 echo "Finished loading the $1 database!"

--- a/upgrade_mongo_3_6.sh
+++ b/upgrade_mongo_3_6.sh
@@ -10,12 +10,13 @@ NC='\033[0m' # No Color
 export MONGO_VERSION=3.4.24
 
 echo -e "${GREEN}Sarting Mongo ${MONGO_VERSION}${NC}"
-docker-compose up -d mongo
+make dev.up.mongo
+mongo_container="$(make -s dev.print-container.mongo)"
 
 echo -e "${GREEN}Waiting for MongoDB...${NC}"
-until docker-compose exec -T mongo bash -c 'mongo --eval \"printjson(db.serverStatus())\"' &> /dev/null
+until docker exec "$mongo_container" bash -c 'mongo --eval \"printjson(db.serverStatus())\"' &> /dev/null
 do
-    if docker-compose logs mongo | grep -q "BadValue: Invalid value for version, found 3.6, expected '3.4' or '3.2'"; then
+    if docker logs "$mongo_container" | grep -q "BadValue: Invalid value for version, found 3.6, expected '3.4' or '3.2'"; then
         echo -e "${YELLOW}Already upgraded to Mongo 3.6, exiting${NC}"
         exit
     fi
@@ -24,15 +25,15 @@ do
 done
 
 echo -e "${GREEN}MongoDB ready.${NC}"
-MONGO_VERSION_LIVE=$(docker-compose exec mongo mongo --quiet --eval "printjson(db.version())")
-MONGO_VERSION_COMPAT=$(docker-compose exec mongo mongo --quiet \
+MONGO_VERSION_LIVE=$(docker exec -it "$mongo_container" mongo --quiet --eval "printjson(db.version())")
+MONGO_VERSION_COMPAT=$(docker exec -it "$mongo_container" mongo --quiet \
     --eval "printjson(db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )['featureCompatibilityVersion'])")
 echo -e "${GREEN}Mongo Server version: ${MONGO_VERSION_LIVE}${NC}"
 echo -e "${GREEN}Mongo FeatureCompatibilityVersion version: ${MONGO_VERSION_COMPAT}${NC}"
 
 if echo "${MONGO_VERSION_COMPAT}" | grep -q "3\.2" ; then
     echo -e "${GREEN}Upgrading FeatureCompatibilityVersion to 3.4${NC}"
-    docker-compose exec mongo mongo --eval "db.adminCommand( { setFeatureCompatibilityVersion: \"3.4\" } )"
+    docker exec -it "$mongo_container" mongo --eval "db.adminCommand( { setFeatureCompatibilityVersion: \"3.4\" } )"
 else
     echo -e "${GREEN}FeatureCompatibilityVersion already set to 3.4${NC}"
 fi
@@ -42,25 +43,26 @@ export MONGO_VERSION=3.6.17
 
 echo
 echo -e "${GREEN}Restarting Mongo on version ${MONGO_VERSION}${NC}"
-docker-compose up -d mongo
+make dev.up.mongo
+mongo_container="$(make -s dev.print-container.mongo)"
 
 echo -e "${GREEN}Waiting for MongoDB...${NC}"
-until docker-compose exec -T mongo bash -c 'mongo --eval \"printjson(db.serverStatus())\"' &> /dev/null
+until docker exec "$mongo_container" bash -c 'mongo --eval \"printjson(db.serverStatus())\"' &> /dev/null
 do
     printf "."
     sleep 1
 done
 
 echo -e "${GREEN}MongoDB ready.${NC}"
-MONGO_VERSION_LIVE=$(docker-compose exec mongo mongo --quiet --eval "printjson(db.version())")
-MONGO_VERSION_COMPAT=$(docker-compose exec mongo mongo --quiet \
+MONGO_VERSION_LIVE=$(docker exec -it "$mongo_container" mongo --quiet --eval "printjson(db.version())")
+MONGO_VERSION_COMPAT=$(docker exec -it "$mongo_container" mongo --quiet \
     --eval "printjson(db.adminCommand( { getParameter: 1, featureCompatibilityVersion: 1 } )['featureCompatibilityVersion'])")
 echo -e "${GREEN}Mongo Server version: ${MONGO_VERSION_LIVE}${NC}"
 echo -e "${GREEN}Mongo FeatureCompatibilityVersion version: ${MONGO_VERSION_COMPAT}${NC}"
 
 if echo "${MONGO_VERSION_COMPAT}" | grep -q "3\.4" ; then
     echo -e "${GREEN}Upgrading FeatureCompatibilityVersion to 3.6${NC}"
-    docker-compose exec mongo mongo --eval "db.adminCommand( { setFeatureCompatibilityVersion: \"3.6\" } )"
+    docker exec -it "$mongo_container" mongo --eval "db.adminCommand( { setFeatureCompatibilityVersion: \"3.6\" } )"
 else
     echo -e "${GREEN}FeatureCompatibilityVersion already set to 3.6${NC}"
 fi


### PR DESCRIPTION
@ztraboo 
```
Because environment variables are set in options.mk and
options.local.mk currently, we cannot assume that
docker-compose commands will work currently unless:
(1) They are within the Makefile, or
(2) They are in a script that is called by the Makefile.

Other scripts must use dev.print-container.% to get the
ID of a service's container, with which it can then use
plain docker commands.

Also, this commit adds a dev.restart.% target so that
the README does not suggest bare use of docker-compose.

Ideally, this situtation should be remedied in the future by
moving docker-compose environment variables to a .env file;
however, we aren't sure how we would support local overrides
in that setup.
```