### PR TITLE
[Backport] Merge pull request #865 from edx/pshiu/add-zlib-to-devstack

### DIFF
--- a/microfrontend.yml
+++ b/microfrontend.yml
@@ -7,6 +7,6 @@ services:
     command: bash -c 'npm install; while true; do npm start; sleep 2; done'
     stdin_open: true
     tty: true
-    image: node:12
+    image: node:12-bullseye
     environment:
       - NODE_ENV=development


### PR DESCRIPTION
fix: bump node image for microfrontends for mozjpeg-bin

Ran into this issue when trying to access the new `frontend-app-learning` from the `maple.master` devstack install. Used https://github.com/openedx/devstack/pull/865 to fix the issue.

![microfrontend-issue-mozjpeg](https://user-images.githubusercontent.com/5641338/149156427-e8197b9c-9754-4354-9875-8f7811a2a546.png)

Upstream: https://github.com/openedx/devstack/pull/882